### PR TITLE
dbコンテナが落ちてしまうので、volumeの方法を修正

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,7 +43,8 @@ services:
     ports:
       - 3306:3306
     volumes:
-      - ./mysql/.volumes:/var/lib/mysql
+      - db-volume:/var/lib/mysql
+      - ./mysql/my.cnf:/etc/mysql/conf.d/my.cnf
     environment:
       MYSQL_USER: tyamahori
       MYSQL_ROOT_PASSWORD: tyamahori
@@ -83,3 +84,6 @@ services:
     container_name: tyamahori-mailhog
     ports:
       - 8025:8025
+
+volumes:
+  db-volume:

--- a/docker/mysql/my.cnf
+++ b/docker/mysql/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+max_allowed_packet=256M


### PR DESCRIPTION
- docker-compose にてdbコンテナが落ちてしまうことが頻発するので、その対応を行う。